### PR TITLE
Added Prometheus datasource to Grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
     depends_on:
       - prometheus
 

--- a/grafana/provisioning/datasources/prometheus.yaml
+++ b/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION
When you start the project for the first time, the Prometheus Datasource is not configured to import the metrics.